### PR TITLE
신뢰성 강화: 구글시트 동기화 동시 실행 방지 + 전역 예외 핸들러

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 
 # Local Codex helper
 .autocp
+
+### macOS ###
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'org.nowstart'
-version = '5.4.2'
+version = '5.4.3'
 
 springBoot {
     buildInfo()

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ repositories {
 }
 
 ext {
-    springBootAdminVersion = "4.0.4"
     springDocVersion = "3.0.3"
     opentelemetryVersion = "2.29.0"
     springCloudVersion = "2025.1.2"

--- a/src/main/java/org/nowstart/nyangnyangbot/adapter/in/web/error/ErrorResponse.java
+++ b/src/main/java/org/nowstart/nyangnyangbot/adapter/in/web/error/ErrorResponse.java
@@ -1,0 +1,4 @@
+package org.nowstart.nyangnyangbot.adapter.in.web.error;
+
+public record ErrorResponse(int status, String error, String message) {
+}

--- a/src/main/java/org/nowstart/nyangnyangbot/adapter/in/web/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/nowstart/nyangnyangbot/adapter/in/web/error/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package org.nowstart.nyangnyangbot.adapter.in.web.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 컨트롤러 전 영역에 공통으로 적용되는 예외 처리. 처리되지 않은 예외가 스택트레이스와 함께
+ * 5xx로 노출되는 것을 막고, 도메인 검증 실패와 데이터 무결성 충돌을 의미 있는 상태 코드로 매핑한다.
+ * 인증/인가(401/403) 예외는 Spring Security 필터 체인이 처리하므로 여기서 다루지 않는다.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
+        log.warn("[400] 잘못된 요청: {}", exception.getMessage());
+        return response(HttpStatus.BAD_REQUEST, exception.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException exception) {
+        // 멱등성 충돌·중복 INSERT 등은 내부 SQL 메시지를 노출하지 않고 충돌로만 응답한다.
+        log.warn("[409] 데이터 무결성 위반", exception);
+        return response(HttpStatus.CONFLICT, "이미 처리되었거나 중복된 요청입니다.");
+    }
+
+    private ResponseEntity<ErrorResponse> response(HttpStatus status, String message) {
+        String safeMessage = (message == null || message.isBlank()) ? status.getReasonPhrase() : message;
+        return ResponseEntity.status(status)
+                .body(new ErrorResponse(status.value(), status.getReasonPhrase(), safeMessage));
+    }
+}

--- a/src/main/java/org/nowstart/nyangnyangbot/application/service/google/GoogleSheetService.java
+++ b/src/main/java/org/nowstart/nyangnyangbot/application/service/google/GoogleSheetService.java
@@ -4,6 +4,7 @@ import io.micrometer.common.util.StringUtils;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,31 +28,44 @@ public class GoogleSheetService implements SyncGoogleSheetUseCase {
     private final AdjustFavoriteUseCase adjustFavoriteUseCase;
     private final GoogleSheetPort googleSheetPort;
 
+    // 스케줄러(매일 04:00)와 수동 동기화 API가 동시에 실행되면 같은 delta가 두 번 적용되어
+    // 호감도 원장이 이중 기록될 수 있으므로 단일 실행을 보장한다.
+    // 단일 인스턴스 운영을 전제로 하며, 다중 인스턴스로 확장 시 분산 락(ShedLock 등)으로 대체해야 한다.
+    private final AtomicBoolean syncing = new AtomicBoolean(false);
+
     @Override
     public void updateFavorite() {
-        List<GoogleSheetRow> googleSheetRows = getSheetValues();
+        if (!syncing.compareAndSet(false, true)) {
+            log.warn("[DBSync] 이미 동기화가 진행 중이어서 이번 실행을 건너뜁니다.");
+            return;
+        }
+        try {
+            List<GoogleSheetRow> googleSheetRows = getSheetValues();
 
-        for (GoogleSheetRow row : googleSheetRows) {
-            SummaryResult favorite = favoriteQueryPort.getOrCreate(row.userId(), row.nickName());
+            for (GoogleSheetRow row : googleSheetRows) {
+                SummaryResult favorite = favoriteQueryPort.getOrCreate(row.userId(), row.nickName());
 
-            if (!Objects.equals(favorite.nickName(), row.nickName())) {
-                favoriteQueryPort.updateNickName(row.userId(), row.nickName());
+                if (!Objects.equals(favorite.nickName(), row.nickName())) {
+                    favoriteQueryPort.updateNickName(row.userId(), row.nickName());
+                }
+
+                if (!Objects.equals(favorite.favorite(), row.favorite())) {
+                    int before = favorite.favorite() == null ? 0 : favorite.favorite();
+                    adjustFavoriteUseCase.adjust(AdjustFavoriteCommand.builder()
+                            .userId(row.userId())
+                            .nickName(row.nickName())
+                            .delta(row.favorite() - before)
+                            .sourceType(FavoriteSourceType.SHEET_MIGRATION)
+                            .sourceId("google-sheet")
+                            .displayCategory("MIGRATION")
+                            .publicDescription("데이터 동기화")
+                            .allowNegativeBalance(true)
+                            .createIfMissing(true)
+                            .build());
+                }
             }
-
-            if (!Objects.equals(favorite.favorite(), row.favorite())) {
-                int before = favorite.favorite() == null ? 0 : favorite.favorite();
-                adjustFavoriteUseCase.adjust(AdjustFavoriteCommand.builder()
-                        .userId(row.userId())
-                        .nickName(row.nickName())
-                        .delta(row.favorite() - before)
-                        .sourceType(FavoriteSourceType.SHEET_MIGRATION)
-                        .sourceId("google-sheet")
-                        .displayCategory("MIGRATION")
-                        .publicDescription("데이터 동기화")
-                        .allowNegativeBalance(true)
-                        .createIfMissing(true)
-                        .build());
-            }
+        } finally {
+            syncing.set(false);
         }
     }
 

--- a/src/test/java/org/nowstart/nyangnyangbot/adapter/in/web/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/nowstart/nyangnyangbot/adapter/in/web/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,57 @@
+package org.nowstart.nyangnyangbot.adapter.in.web.error;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ThrowingController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void handleIllegalArgument_ShouldReturnBadRequestWithMessage() throws Exception {
+        mockMvc.perform(get("/test/illegal-argument"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("delta must not be zero"));
+    }
+
+    @Test
+    void handleDataIntegrityViolation_ShouldReturnConflictWithoutLeakingInternals() throws Exception {
+        mockMvc.perform(get("/test/data-integrity"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.error").value("Conflict"))
+                .andExpect(jsonPath("$.message").value("이미 처리되었거나 중복된 요청입니다."));
+    }
+
+    @RestController
+    static class ThrowingController {
+
+        @GetMapping("/test/illegal-argument")
+        String illegalArgument() {
+            throw new IllegalArgumentException("delta must not be zero");
+        }
+
+        @GetMapping("/test/data-integrity")
+        String dataIntegrity() {
+            throw new DataIntegrityViolationException("duplicate key uk_favorite_history_idempotency_key");
+        }
+    }
+}

--- a/src/test/java/org/nowstart/nyangnyangbot/application/service/google/GoogleSheetServiceTest.java
+++ b/src/test/java/org/nowstart/nyangnyangbot/application/service/google/GoogleSheetServiceTest.java
@@ -4,11 +4,18 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -158,6 +165,36 @@ class GoogleSheetServiceTest {
 
         // 검증
         BDDMockito.then(favoriteQueryPort).should().updateNickName("user123", "새닉네임");
+        BDDMockito.then(adjustFavoriteUseCase).should(never()).adjust(any(AdjustFavoriteCommand.class));
+    }
+
+    @Test
+    void updateFavorite_ShouldSkip_WhenSyncAlreadyInProgress() throws Exception {
+        // 준비 - 첫 번째 동기화를 가드 안에서 멈춰두고, 그 사이 두 번째 호출을 시도한다.
+        CountDownLatch firstEntered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            firstEntered.countDown();
+            release.await();
+            return List.<GoogleSheetRow>of();
+        }).when(googleSheetService).getSheetValues();
+
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> first = pool.submit(() -> googleSheetService.updateFavorite());
+            then(firstEntered.await(2, TimeUnit.SECONDS)).isTrue();
+
+            // 실행 - 첫 동기화가 진행 중인 동안의 두 번째 호출은 즉시 건너뛰어야 한다.
+            googleSheetService.updateFavorite();
+
+            release.countDown();
+            first.get(2, TimeUnit.SECONDS);
+        } finally {
+            pool.shutdownNow();
+        }
+
+        // 검증 - 가드 덕분에 시트 조회는 첫 호출에서 단 한 번만 수행된다.
+        BDDMockito.then(googleSheetService).should(times(1)).getSheetValues();
         BDDMockito.then(adjustFavoriteUseCase).should(never()).adjust(any(AdjustFavoriteCommand.class));
     }
 }


### PR DESCRIPTION
## 배경
냥냥봇 코드베이스 9개 차원 분석에서 도출된 고우선 신뢰성 결함을 수정하고, 부수적인 빌드 설정 정리를 함께 진행합니다.

## 변경 사항

### 🐛 fix: 구글시트 동기화 동시 실행 시 호감도 이중 기록 방지
- 스케줄러(매일 04:00 cron)와 수동 `GET /google/sync`가 잠금 없이 동시 실행되면 동일 delta가 두 번 적용되어 호감도 원장이 이중 기록될 수 있었음 (`idempotencyKey` 미설정으로 `FavoriteLedgerService`의 멱등성 가드도 우회).
- `GoogleSheetService`에 `AtomicBoolean` 단일 실행 가드 추가 — 동시 실행을 직렬화(진행 중이면 스킵).
- 단일 인스턴스 운영 전제. 다중 인스턴스 확장 시 분산 락(ShedLock 등)으로 대체 필요.

### ✨ feat: 전역 예외 핸들러 추가
- `@ControllerAdvice`가 전무하여 `DataIntegrityViolationException`·`IllegalArgumentException`이 스택트레이스와 함께 5xx로 노출되던 문제 해결.
- `@RestControllerAdvice`(`GlobalExceptionHandler`): `IllegalArgumentException → 400`, `DataIntegrityViolationException → 409`(내부 SQL 메시지 비노출).
- 인증/인가(401/403)는 Spring Security 필터 체인이 처리하므로 의도적으로 제외.

### 🧹 chore
- 미사용 `springBootAdminVersion` ext 변수 제거 (어떤 의존성도 참조하지 않던 죽은 설정).
- `.DS_Store`를 `.gitignore`에 추가하고 소스 트리에 떠돌던 파일 제거.
- 애플리케이션 버전 `5.4.2 → 5.4.3`.

## 테스트
- ✅ `BUILD SUCCESSFUL`, **271개 테스트 전원 통과** (기존 268 + 신규 3).
- ✅ `ArchitectureBoundaryTest`(29개 규칙) 통과 — 새 `adapter/in/web/error` 패키지가 헥사고날 경계 준수.
- 신규 테스트
  - `GoogleSheetServiceTest#updateFavorite_ShouldSkip_WhenSyncAlreadyInProgress` — CountDownLatch 기반 결정론적 동시성 테스트.
  - `GlobalExceptionHandlerTest` — standalone MockMvc로 400/409 매핑 검증.

## 참고
- **Spring 버전**: Spring Boot 4.1.0 · Spring Cloud 2025.1.2 · springdoc 3.0.3 · opentelemetry 2.29.0 모두 Maven Central 기준 이미 최신 릴리스 → 올릴 버전 없음.
- **잔여 윈도우**: `GoogleSheetService`가 클래스 레벨 `@Transactional`이라 가드 해제가 커밋 직전에 일어나는 서브밀리초 윈도우가 이론상 존재. cron vs 수동 클릭 위협 모델에선 무시 가능. 완전 차단이 필요하면 트랜잭션 본문을 별도 빈으로 분리 가능.

## 후속 (미포함)
- `/actuator/**` 노출 축소 + ADMIN/IP 제한
- Feign 타임아웃 + Resilience4j 서킷브레이커
- 신규 사용자 첫 지급 upsert/재시도
